### PR TITLE
Make Farbgeber a MsgFlo participant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colour==0.0.5
-paho-mqtt==1.2
+msgflo==0.0.16


### PR DESCRIPTION
Removes direct MQTT sending in favor of [msgflo-python](https://github.com/msgflo/msgflo-python).

Note that right now sending non-JSON-serializable payloads doesn't work, msgflo/msgflo-python#16

Runnable at c-beam with:

```shell
$ export MSGFLO_BROKER=mqtt://10.0.1.17
$ msgflo-python farbgeber.py farbgeber
```